### PR TITLE
Spawn support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,16 +7,17 @@ requested. :sparkles:
 
 ## Discuss the changes before doing them
  - First of all, open an issue in the repository, using the [bug tracker][1],
-   describing the contribution you'd like to make, the bug you found or any
+   describing the contribution you would like to make, the bug you found or any
    other ideas you have. This will help us to get you started on the right
    foot.
 
  - If it makes sense, add the platform and software information (e.g. operating
-   system, Node.JS version etc), screenshots (so we can see what you're seeing).
+   system, Node.JS version etc.), screenshots (so we can see what you are
+   seeing).
 
- - It's recommended to wait for feedback before continuing to next steps. However,
-   if the issue is clear (e.g. a typo) and the fix is simple, you can continue
-   and fix it.
+ - It is recommended to wait for feedback before continuing to next steps.
+   However, if the issue is clear (e.g. a typo) and the fix is simple, you can
+   continue and fix it.
 
 ## Fixing issues
  - Fork the project in your account and create a branch with your fix:
@@ -26,13 +27,14 @@ requested. :sparkles:
    [code style][2]. If the project contains tests (generally, the `test`
    directory), you are encouraged to add a test as well. :memo:
 
- - If the project contains a `package.json` file add yourself in the
-   `contributors` array (if it doesn't exist, create it):
+ - If the project contains a `package.json` or a `bower.json` file add yourself
+   in the `contributors` array (or `authors` in the case of `bower.json`;
+   if the array does not exist, create it):
 
    ```json
    {
       "contributors": [
-         "Your Name <and@email.address> (http://your.website)
+         "Your Name <and@email.address> (http://your.website)"
       ]
    }
    ```
@@ -40,11 +42,11 @@ requested. :sparkles:
 ## Creating a pull request
 
  - Open a pull request, and reference the initial issue in the pull request
-   message (e.g. *fixes #<your-issue-number*). Write a good description and
+   message (e.g. *fixes #<your-issue-number>*). Write a good description and
    title, so everybody will know what is fixed/improved.
 
- - If it makes sense, add screenshots, gifs etc, so it's easier to see what's
-   going on.
+ - If it makes sense, add screenshots, gifs etc., so it is easier to see what
+   is going on.
 
 ## Wait for feedback
 Before accepting your contributions, we will review them. You may get feedback
@@ -53,8 +55,10 @@ in your branch and the pull request will be updated automatically.
 
 ## Everyone is happy!
 Finally, your contributions will be merged, and everyone will be happy! :smile:
+Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
 [1]: https://github.com/IonicaBizau/node-exec-limiter/issues
+
 [2]: https://github.com/IonicaBizau/code-style

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The KINDLY License
-Copyright (c) 2015 Ionică Bizău <bizauionica@yahoo.com>
+Copyright (c) 2015 Ionică Bizău <bizauionica@gmail.com>
 
 You have the permission to use this software, read its source code, modify and
 redistribute it under the following terms:

--- a/README.md
+++ b/README.md
@@ -33,17 +33,31 @@ var ExecLimiter = require("exec-limiter");
 const COMMAND = "sleep 5; date;";
 
 // Create an instance of exec limiter
-var el = new ExecLimiter(10)
-  , i = 0
-  , c = 0
-  ;
+var el = new ExecLimiter(2);
 
-// Exec the command 30 times, but not more than 10 same time
-for (; i < 30; ++i) {
-    el.add(COMMAND, function (err, stdout) {
-        console.log((++c) + "> " + stdout);
-    });
-}
+// #1
+el.add("sleep 5", function (err) {
+    console.log(err || "Waited 5 seconds for the first time.");
+});
+
+// #2
+el.add("sleep", ["7"], function (err) {
+    console.log(err || "Waited another 7 seconds but probably I was ran in parallel with the other process.");
+});
+
+// #3
+el.add("sleep 5", function (err) {
+    console.log(err || "I was ran in parallel with the second process and finished fine.");
+});
+
+// These will be executed like below:
+//
+// Timeline: 0-1-2-3-4-5-6-7-8-9-10
+//       #1: ==========
+//       #2: ==============
+//       #3:            ============
+//
+// Notice how they run in parallel, but not more than 2 in the same time.
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -50,12 +50,19 @@ el.add("sleep 5", function (err) {
     console.log(err || "I was ran in parallel with the second process and finished fine.");
 });
 
+// #4
+el.add("ls", ["-l"], { ignoreStdout: false }, function (err, stdout) {
+    console.log(err || "The spawned 'ls -l' returned:\n" + stdout);
+});
+
 // These will be executed like below:
 //
-// Timeline: 0-1-2-3-4-5-6-7-8-9-10
+// Timeline: 0-1-2-3-4-5-6-7-8-9-10-11
+//
 //       #1: ==========
 //       #2: ==============
 //       #3:            ============
+//       #4:               ==
 //
 // Notice how they run in parallel, but not more than 2 in the same time.
 ```
@@ -74,10 +81,20 @@ Creates a new instance of `ExecLimiter`.
 ### `add(command, args, options, callback)`
 Adds a new command to run in the buffer.
 
+Usage:
+
+```js
+el.add(command, fn); // exec
+el.add(command, args, fn); // spawn
+el.add(command, options, fn); // exec
+el.add(command, args, options, fn); // spawn
+```
+
 #### Params
 - **String** `command`: The command to run as string.
 - **Object** `args`: The command arguments as array of strings (optional).
-- **Object** `options`: The options to pass to the exec/spawn function (optional).
+- **Object** `options`: The options passed to the spawn/exec function, but extended with the following fields:
+ - `ignoreStdout` (Boolean): If `false`, then the stdout output will be stored ant called back.
 - **Function** `callback`: The callback function.
 
 #### Return

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ for (; i < 30; ++i) {
         console.log((++c) + "> " + stdout);
     });
 }
-
 ```
 
 ## Documentation
@@ -58,12 +57,13 @@ Creates a new instance of `ExecLimiter`.
 #### Return
 - **ExecLimiter** The `ExecLimiter` instance.
 
-### `add(command, options, callback)`
+### `add(command, args, options, callback)`
 Adds a new command to run in the buffer.
 
 #### Params
-- **String** `command`: The command to run.
-- **Object** `options`: The options to pass to the exec function.
+- **String** `command`: The command to run as string.
+- **Object** `args`: The command arguments as array of strings (optional).
+- **Object** `options`: The options to pass to the exec/spawn function (optional).
 - **Function** `callback`: The callback function.
 
 #### Return
@@ -71,6 +71,9 @@ Adds a new command to run in the buffer.
 
 ## How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
+
+## Who uses this
+If you are using this library in one of your projects, add it in this list. :sparkles:
 
 ## License
 [KINDLY][license] © [Ionică Bizău][website]–The [LICENSE](/LICENSE) file contains
@@ -81,4 +84,4 @@ a copy of the license.
 [website]: http://ionicabizau.net
 [docs]: /DOCUMENTATION.md
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MG98D7NPFZ3MG
-[donate-now]: http://i.imgur.com/jioicaN.png
+[donate-now]: http://i.imgur.com/6cMbHOC.png

--- a/example/index.js
+++ b/example/index.js
@@ -5,14 +5,28 @@ var ExecLimiter = require("../lib");
 const COMMAND = "sleep 5; date;";
 
 // Create an instance of exec limiter
-var el = new ExecLimiter(10)
-  , i = 0
-  , c = 0
-  ;
+var el = new ExecLimiter(2);
 
-// Exec the command 30 times, but not more than 10 same time
-for (; i < 30; ++i) {
-    el.add(COMMAND, function (err, stdout) {
-        console.log((++c) + "> " + stdout);
-    });
-}
+// #1
+el.add("sleep 5", function (err) {
+    console.log(err || "Waited 5 seconds for the first time.");
+});
+
+// #2
+el.add("sleep", ["7"], function (err) {
+    console.log(err || "Waited another 7 seconds but probably I was ran in parallel with the other process.");
+});
+
+// #3
+el.add("sleep 5", function (err) {
+    console.log(err || "I was ran in parallel with the second process and finished fine.");
+});
+
+// These will be executed like below:
+//
+// Timeline: 0-1-2-3-4-5-6-7-8-9-10
+//       #1: ==========
+//       #2: ==============
+//       #3:            ============
+//
+// Notice how they run in parallel, but not more than 2 in the same time.

--- a/example/index.js
+++ b/example/index.js
@@ -22,11 +22,18 @@ el.add("sleep 5", function (err) {
     console.log(err || "I was ran in parallel with the second process and finished fine.");
 });
 
+// #4
+el.add("ls", ["-l"], { ignoreStdout: false }, function (err, stdout) {
+    console.log(err || "The spawned 'ls -l' returned:\n" + stdout);
+});
+
 // These will be executed like below:
 //
-// Timeline: 0-1-2-3-4-5-6-7-8-9-10
+// Timeline: 0-1-2-3-4-5-6-7-8-9-10-11
+//
 //       #1: ==========
 //       #2: ==============
 //       #3:            ============
+//       #4:               ==
 //
 // Notice how they run in parallel, but not more than 2 in the same time.

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,15 +36,21 @@ function ExecLimiter(limit) {
  * @name add
  * @function
  * @param {String} command The command to run as string.
- * @param {Object} args    The command arguments as array of strings (optional).
- * @param {Object} options The options to pass to the exec/spawn function (optional).
+ * @param {Object} args The command arguments as array of strings (optional).
+ * @param {Object} options The options passed to the spawn/exec function, but extended with the following fields:
+ *
+ *  - `ignoreStdout` (Boolean): If `false`, then the stdout output will be stored ant called back.
+ *
  * @param {Function} callback The callback function.
  * @return {ExecLimiter} The `ExecLimiter` instance.
  */
 ExecLimiter.prototype.add = function (command, args, options, callback) {
 
-    var useExec = false;
+    var useExec = false
+      , largs = []
+      ;
 
+    // add(command, fn);
     if (typeof args === "function") {
         callback = args;
         options = {};
@@ -52,8 +58,10 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
         useExec = true;
     } else if (typeof options === "function") {
         callback = options;
+        // add(command, args, fn);
         if (Array.isArray(args)) {
             options = {};
+        // add(command, options, fn);
         } else {
             options = args;
             args = [];
@@ -62,15 +70,31 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
     }
 
     // Prepare the arguments for the limit-it call
-    var largs = [];
-
     if (useExec) {
         largs = [command, options];
     } else {
         largs = [command, args, options];
     }
 
+    /*!
+     * spawner
+     * Spawns the process.
+     *
+     * @name spawner
+     * @function
+     * @param {String} command The command to run.
+     * @param {Array} args The options array.
+     * @param {Object} options The options passed to the spawn function, but extended with the following fields:
+     *
+     *  - `ignoreStdout` (Boolean): If `false`, then the stdout output will be stored ant called back.
+     *
+     * @param {Function} callback The callback function.
+     */
     function spawner(command, args, options, callback) {
+
+        var ignoreStdout = options.ignoreStdout;
+        delete options.ignoreStdout;
+
         var child = ChildProcess.spawn(command, args, options)
           , err = ""
           , out = ""
@@ -81,7 +105,7 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
         });
 
         // By default, we don't store the stdout
-        if (options && options.ignoreStdout === false) {
+        if (ignoreStdout === false) {
             child.stdout.on("data", function (chunk) {
                 out += chunk;
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,15 @@ function ExecLimiter(limit) {
  * add
  * Adds a new command to run in the buffer.
  *
+ * Usage:
+ *
+ * ```js
+ * el.add(command, fn); // exec
+ * el.add(command, args, fn); // spawn
+ * el.add(command, options, fn); // exec
+ * el.add(command, args, options, fn); // spawn
+ * ```
+ *
  * @name add
  * @function
  * @param {String} command The command to run as string.
@@ -56,29 +65,35 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
     var largs = [];
 
     if (useExec) {
-        // Watch for white spaces in values
-        for (var i in args) {
-            command += " \"" + args[i] + "\"";
-        }
         largs = [command, options];
     } else {
         largs = [command, args, options];
     }
 
     function spawner(command, args, options, callback) {
-        var child = ChildProcess.spawn(command, args, options);
-        var err;
+        var child = ChildProcess.spawn(command, args, options)
+          , err = ""
+          , out = ""
+          ;
+
         child.stderr.on("data", function (data) {
-            err = err || "";
             err += data;
         });
+
+        // By default, we don't store the stdout
+        if (options && options.ignoreStdout === false) {
+            child.stdout.on("data", function (chunk) {
+                out += chunk;
+            });
+        }
+
         child.on("close", function (code) {
             var error = null;
             if (code) {
-                var error = new Error(err);
+                error = new Error(err);
                 error.code = code;
             }
-            callback(error);
+            callback(error, out);
         });
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,7 @@
 // Dependencies
-var Exec = require("child_process").exec
-  , LimitIt = require("limit-it")
-  , Typpy = require("typpy")
-  ;
+var cp = require("child_process");
+var LimitIt = require("limit-it");
+var Typpy = require("typpy");
 
 /**
  * ExecLimiter
@@ -26,19 +25,60 @@ function ExecLimiter(limit) {
  *
  * @name add
  * @function
- * @param {String} command The command to run.
- * @param {Object} options The options to pass to the exec function.
+ * @param {String} command The command to run as string.
+ * @param {Object} args    The command arguments as array of strings (optional).
+ * @param {Object} options The options to pass to the exec/spawn function (optional).
  * @param {Function} callback The callback function.
  * @return {ExecLimiter} The `ExecLimiter` instance.
  */
-ExecLimiter.prototype.add = function (command, options, callback) {
+ExecLimiter.prototype.add = function (command, args, options, callback) {
 
-    if (typeof options === "function") {
-        callback = options;
+    var useExec = false;
+
+    // check the optional parameters
+    if (typeof args === "function") {
+        callback = args;
         options = {};
+        args = [];
+        useExec = true;
+    } else if (typeof options === "function") {
+        callback = options;
+        // we must have either the args or the options
+        if (args instanceof Array) {
+            options = {};
+        } else {
+            options = args;
+            args = [];
+            useExec = true;
+        }
     }
 
-    this.limitIt.add(Exec, [command, options], callback);
+    // prepare the arguments for the limit-it call
+    var largs = [];
+
+    if (useExec) {
+        // watch for whitespaces in values
+        for (var i in args) {
+            command += " \"" + args[i] + "\"";
+        }
+        largs = [command, options];
+    } else {
+        largs = [command, args, options];
+    }
+
+    function spawner(command, args, options, callback) {
+        var child = cp.spawn(command, args, options);
+        var err;
+        child.stderr.on("data", function (data) {
+            err = err || "";
+            err += data;
+        });
+        child.on("close", function (code) {
+            callback(err);
+        });
+    }
+
+    this.limitIt.add(useExec ? cp.exec : spawner, largs, callback);
     return this;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 // Dependencies
-var cp = require("child_process");
-var LimitIt = require("limit-it");
-var Typpy = require("typpy");
+var ChildProcess = require("child_process")
+  , LimitIt = require("limit-it")
+  , Typpy = require("typpy")
+  ;
 
 /**
  * ExecLimiter
@@ -35,7 +36,6 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
 
     var useExec = false;
 
-    // check the optional parameters
     if (typeof args === "function") {
         callback = args;
         options = {};
@@ -43,8 +43,7 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
         useExec = true;
     } else if (typeof options === "function") {
         callback = options;
-        // we must have either the args or the options
-        if (args instanceof Array) {
+        if (Array.isArray(args)) {
             options = {};
         } else {
             options = args;
@@ -53,11 +52,11 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
         }
     }
 
-    // prepare the arguments for the limit-it call
+    // Prepare the arguments for the limit-it call
     var largs = [];
 
     if (useExec) {
-        // watch for whitespaces in values
+        // Watch for white spaces in values
         for (var i in args) {
             command += " \"" + args[i] + "\"";
         }
@@ -67,7 +66,7 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
     }
 
     function spawner(command, args, options, callback) {
-        var child = cp.spawn(command, args, options);
+        var child = ChildProcess.spawn(command, args, options);
         var err;
         child.stderr.on("data", function (data) {
             err = err || "";
@@ -83,7 +82,7 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
         });
     }
 
-    this.limitIt.add(useExec ? cp.exec : spawner, largs, callback);
+    this.limitIt.add(useExec ? ChildProcess.exec : spawner, largs, callback);
     return this;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,12 @@ ExecLimiter.prototype.add = function (command, args, options, callback) {
             err += data;
         });
         child.on("close", function (code) {
-            callback(err);
+            var error = null;
+            if (code) {
+                var error = new Error(err);
+                error.code = code;
+            }
+            callback(error);
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "node example"
+    "test": "mocha test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "limiter",
     "shell"
   ],
-  "author": "Ionică Bizău <bizauionica@gmail.com>",
+  "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
   "contributors": [
     "Gabriel Petrovay <gabipetrovay@gmail.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "shell"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com>",
+  "contributors": [
+    "Gabriel Petrovay <gabipetrovay@gmail.com>"
+  ],
   "license": "KINDLY",
   "bugs": {
     "url": "https://github.com/IonicaBizau/node-exec-limiter/issues"

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "Limit the shell execution commands to <x> calls same time.",
   "main": "lib/index.js",
   "directories": {
-    "example": "example"
+    "example": "example",
+    "test": "test"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "mocha test"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:IonicaBizau/node-exec-limiter.git"
+    "url": "git+ssh://git@github.com/IonicaBizau/node-exec-limiter.git"
   },
   "keywords": [
     "exec",
@@ -30,6 +30,9 @@
   "homepage": "https://github.com/IonicaBizau/node-exec-limiter",
   "dependencies": {
     "limit-it": "^3.0.0",
-    "typpy": "^2.0.0"
+    "typpy": "^2.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exec-limiter",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Limit the shell execution commands to <x> calls same time.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,28 @@ describe("ExecLimiter", function() {
                 });
             });
         });
+
+        describe("environment", function() {
+            // all tests must finish in less than 4 seconds
+            this.timeout(4000);
+
+            var name = "TEST_VAR";
+            var value = "test_value";
+            var command = "printenv";
+
+            it("spawn: " + command + " - should not return an error if variables are passed correctly", function(done) {
+                var env = {};
+                env[name] = value;
+
+                el.add(command, [name], { env: env }, done);
+            });
+
+            it("exec: " + command + " - should not return an error if variables are passed correctly", function(done) {
+                var env = {};
+                env[name] = value;
+
+                el.add(command + " " + name, { env: env }, done);
+            });
+        });
     });
 });
-

--- a/test/index.js
+++ b/test/index.js
@@ -1,70 +1,67 @@
-var ExecLimiter = require("../lib");
-var assert = require("assert");
+// Dependencies
+var ExecLimiter = require("../lib")
+  , assert = require("assert")
+  ;
 
+// Create the exec limiter
 var el = new ExecLimiter(10);
 
-describe("ExecLimiter", function() {
+describe("errors", function () {
+    var command = "ls";
 
-    describe("#add()", function() {
+    it("spawn: " + command + " - should finish gracefully", function (done) {
+        el.add(command, [], done);
+    });
 
-        describe("errors", function() {
+    it("exec: " + command + " - should finish gracefully", function (done) {
+        el.add(command, done);
+    });
+});
 
-            var command = "ls";
+describe("exec vs. spawn", function() {
+    // All tests must finish in less than 4 seconds
+    this.timeout(4000);
 
-            it("spawn: " + command + " - should finish gracefully", function(done) {
-                el.add(command, [], done);
-            });
+    var tts = 2
+      , command = "sleep"
+      ;
 
-            it("exec: " + command + " - should finish gracefully", function(done) {
-                el.add(command, done);
-            });
+    it("spawn: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
+        var start = Date.now();
+        el.add(command, [tts], function(err) {
+            var end = Date.now();
+            done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
         });
+    });
 
-        describe("exec vs. spawn", function() {
-            // all tests must finish in less than 4 seconds
-            this.timeout(4000);
-
-            var tts = 2;
-            var command = "sleep";
-
-            it("spawn: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
-                var start = Date.now();
-                el.add(command, [tts], function(err) {
-                    var end = Date.now();
-                    done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
-                });
-            });
-
-            it("exec: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
-                var start = Date.now();
-                el.add(command + " " + tts, function(err) {
-                    var end = Date.now();
-                    done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
-                });
-            });
+    it("exec: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
+        var start = Date.now();
+        el.add(command + " " + tts, function(err) {
+            var end = Date.now();
+            done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
         });
+    });
+});
 
-        describe("environment", function() {
-            // all tests must finish in less than 4 seconds
-            this.timeout(4000);
+describe("environment", function() {
 
-            var name = "TEST_VAR";
-            var value = "test_value";
-            var command = "printenv";
+    // All tests must finish in less than 4 seconds
+    this.timeout(4000);
 
-            it("spawn: " + command + " - should not return an error if variables are passed correctly", function(done) {
-                var env = {};
-                env[name] = value;
+    var name = "TEST_VAR"
+      , value = "test_value"
+      , command = "printenv"
+      ;
 
-                el.add(command, [name], { env: env }, done);
-            });
+    it("spawn: " + command + " - should not return an error if variables are passed correctly", function(done) {
+        var env = {};
+        env[name] = value;
+        el.add(command, [name], { env: env }, done);
+    });
 
-            it("exec: " + command + " - should not return an error if variables are passed correctly", function(done) {
-                var env = {};
-                env[name] = value;
-
-                el.add(command + " " + name, { env: env }, done);
-            });
-        });
+    it("exec: " + command + " - should not return an error if variables are passed correctly", function(done) {
+        var env = {};
+        env[name] = value;
+        el.add(command + " " + name, { env: env }, done);
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,48 @@
+var ExecLimiter = require("../lib");
+var assert = require("assert");
+
+var el = new ExecLimiter(10);
+
+describe("ExecLimiter", function() {
+
+    describe("#add()", function() {
+
+        describe("errors", function() {
+
+            var command = "ls";
+
+            it("spawn: " + command + " - should finish gracefully", function(done) {
+                el.add(command, [], done);
+            });
+
+            it("exec: " + command + " - should finish gracefully", function(done) {
+                el.add(command, done);
+            });
+        });
+
+        describe("exec vs. spawn", function() {
+            // all tests must finish in less than 4 seconds
+            this.timeout(4000);
+
+            var tts = 2;
+            var command = "sleep";
+
+            it("spawn: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
+                var start = Date.now();
+                el.add(command, [tts], function(err) {
+                    var end = Date.now();
+                    done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
+                });
+            });
+
+            it("exec: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
+                var start = Date.now();
+                el.add(command + " " + tts, function(err) {
+                    var end = Date.now();
+                    done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
+                });
+            });
+        });
+    });
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,31 @@ describe("errors", function () {
     });
 });
 
+describe("stdout", function () {
+    var command = "ls";
+
+    it("spawn: " + command + " - should not have stdout by default", function (done) {
+        el.add(command, [], function (err, stdout) {
+            assert.equal(stdout, "");
+            done(err);
+        });
+    });
+
+    it("spawn: " + command + " - should have stdout by default", function (done) {
+        el.add(command, [], { ignoreStdout: false }, function (err, stdout) {
+            assert.notEqual(stdout, "");
+            done(err);
+        });
+    });
+
+    it("exec: " + command + " - should have stdout", function (done) {
+        el.add(command, function (err, stdout) {
+            assert.equal(typeof stdout, "string");
+            done(err);
+        });
+    });
+});
+
 describe("exec vs. spawn", function () {
     // All tests must finish in less than 4 seconds
     this.timeout(4000);

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ describe("errors", function () {
     });
 });
 
-describe("exec vs. spawn", function() {
+describe("exec vs. spawn", function () {
     // All tests must finish in less than 4 seconds
     this.timeout(4000);
 
@@ -26,24 +26,24 @@ describe("exec vs. spawn", function() {
       , command = "sleep"
       ;
 
-    it("spawn: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
+    it("spawn: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function (done) {
         var start = Date.now();
-        el.add(command, [tts], function(err) {
+        el.add(command, [tts], function (err) {
             var end = Date.now();
             done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
         });
     });
 
-    it("exec: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function(done) {
+    it("exec: " + command + " " + tts + " - should wait at least " + tts + " seconds before it finishes", function (done) {
         var start = Date.now();
-        el.add(command + " " + tts, function(err) {
+        el.add(command + " " + tts, function (err) {
             var end = Date.now();
             done(end - start < tts * 1000 ? "did not finish in more than " + tts + " seconds" : undefined);
         });
     });
 });
 
-describe("environment", function() {
+describe("environment", function () {
 
     // All tests must finish in less than 4 seconds
     this.timeout(4000);
@@ -53,13 +53,13 @@ describe("environment", function() {
       , command = "printenv"
       ;
 
-    it("spawn: " + command + " - should not return an error if variables are passed correctly", function(done) {
+    it("spawn: " + command + " - should not return an error if variables are passed correctly", function (done) {
         var env = {};
         env[name] = value;
         el.add(command, [name], { env: env }, done);
     });
 
-    it("exec: " + command + " - should not return an error if variables are passed correctly", function(done) {
+    it("exec: " + command + " - should not return an error if variables are passed correctly", function (done) {
         var env = {};
         env[name] = value;
         el.add(command + " " + name, { env: env }, done);


### PR DESCRIPTION
Spawn support for `exec-limiter` is a handy way to start child processes, but not using `exec`. 

``` sh
el.add(command, ["some", "arguments"], fn);
```
